### PR TITLE
feat: allow prefixing the generated heading with the repository name

### DIFF
--- a/org-github-issues.el
+++ b/org-github-issues.el
@@ -49,6 +49,11 @@
   :type 'boolean
   :group 'org-github-issues)
 
+(defcustom org-github-issues-headline-prefix nil
+  "Flag to enable prefixing headlines with the repostiory name."
+  :type 'boolean
+  :group 'org-github-issues)
+
 (defcustom org-github-issues-assignee user-login-name
   "The asignee to use for issue filtering."
   :type 'string
@@ -151,7 +156,7 @@
          (body (oref issue body))
          (tags (ogi--labels-to-tags issue))
          (link (ogi--issue-url owner repo number))
-         (params (list :title (format "#%d: %s" number title)
+         (params (list :title (if org-github-issues-headline-prefix (format "%s: #%d: %s" repo number title) (format "#%d: %s" number title))
                        :level (+ level 1)
                        :todo-keyword "TODO")))
       (org-element-interpret-data


### PR DESCRIPTION
This pull request adds a flag that allows prefixing headings with the repository name.

This is very helpful if you are working on multiple repositories and use `org-todo-list`.