### PR TITLE
Allow customization of 'label to tag' regexp and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@
 
 A helper function to create org-mode TODOs out of open issues in a github repository.
 
+## Installation
+
+### Using straight.el
+
+An example of how you can install this package using [straight.el](https://github.com/raxod502/straight.el):
+
+```org
+(use-package org-github-issues :straight (org-github-issues :host github :repo "iensu/org-github-issues")
+  :defer t
+  :config
+  (setq
+        github-repositories '("dekorateio/dekorate" "quarkusio/quarkus")                                                 ;; My repositories
+        org-github-issues-org-file "~/Documents/org/github.org"                                                          ;; My org file
+        org-github-issues-tags '("github" "triage")                                                                      ;; Always add these labels
+        org-github-issues-auto-schedule "+0d"                                                                            ;; Enable automatic scheduling
+        org-github-issues-filter-by-assignee t                                                                           ;; Enable filter by assignee
+        org-github-issues-headline-prefix t)                                                                             ;; Prefix all headlines with repository name
+  (mapcar (lambda (r) (run-with-idle-timer 3600 t (lambda () (org-github-issues-sync-issues r)))) github-repositories))  ;; When idle for an hour loop over my projects and sync
+```
+
+
 ## Usage
 
 Before use you need to set the variable `org-github-issues-org-file` to point to an existing
@@ -28,3 +49,19 @@ Any header that doesn't match the (OWNER/REPO) pattern will be ignored.
 
 After setup you can run `M-x org-github-issues-sync-issues`, which will prompt you for the repository
 you want to fetch issues for.
+
+
+## Customization
+
+The following custom options are available:
+
+| Option                               | Type                             | Description                                                                          | Default Value                |
+|--------------------------------------|----------------------------------|--------------------------------------------------------------------------------------|------------------------------|
+| org-github-issues-org-file           | string                           | Path to an existing `org-mode` file in which to write issues                         | "~/Dropbox/org/projects.org" |
+| org-github-issues-filter-by-assignee | boolean                          | Flag to enable filtering issues by assignee.                                         | nil                          |
+| org-github-issues-assignee           | string                           | The assignee to use for filtering                                                    | `user-login-name`            |
+| org-github-issues-headline-prefix    | boolean                          | Flag to enable prefixing headlines with the repository name                          | nil                          |
+| org-github-issues-auto-schedule      | string                           | Threshold for automatically scheduling new issues                                    | "+0d"                        |
+| org-github-tag-transformations       | alsit :value-type (group-string) | An alsit with trasnformations to apply to github labels when converting them to tags | '(("[\s/-]+" "_")            |
+
+

--- a/org-github-issues.el
+++ b/org-github-issues.el
@@ -49,14 +49,14 @@
   :type 'boolean
   :group 'org-github-issues)
 
+(defcustom org-github-issues-assignee user-login-name
+  "The assignee to use for issue filtering."
+  :type 'string
+  :group 'org-github-issues)
+
 (defcustom org-github-issues-headline-prefix nil
   "Flag to enable prefixing headlines with the repostiory name."
   :type 'boolean
-  :group 'org-github-issues)
-
-(defcustom org-github-issues-assignee user-login-name
-  "The asignee to use for issue filtering."
-  :type 'string
   :group 'org-github-issues)
 
 (defcustom org-github-issues-auto-schedule "+0d"

--- a/org-github-issues.el
+++ b/org-github-issues.el
@@ -64,6 +64,11 @@
   :type 'string
   :group 'org-github-issues)
 
+(defcustom org-github-issues-tag-transformations '(("[\s/-]+" "_"))
+  "An alist with transformation to apply to github labels when converting them to org-mode tags."
+  :type '(alist :value-type (group string))
+  :group 'org-github-issues)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Repository structure
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -151,7 +156,16 @@
 
 (defun ogi--labels-to-tags (issue)
   "Return a string of org tags based on labels from ISSUE."
-  (mapcar (lambda (label) (replace-regexp-in-string "[\s-]+" "_" (oref label name))) (oref issue labels))) ;;Replace chars that are invalid for tags
+  (mapcar (lambda (label) (ogi--replace-multi-regexp-in-string (oref label name) org-github-issues-tag-transformations)) (oref issue labels))) ;;Replace chars that are invalid for tags
+
+(defun ogi--replace-multi-regexp-in-string(s mappings)
+  "Replace multiple replace-regexp-in-string in a pipeline fashion (Feed the result of each step as input to the next)."
+  (let ((result s))
+    (dolist (m mappings)
+      (let ((regexp (car m))
+            (to-replace (car (cdr m))))
+      (setq result (replace-regexp-in-string regexp to-replace result))))
+    result))
 
 (defun ogi--scheduled-property (level)
   "Return the scheduled string property."

--- a/org-github-issues.el
+++ b/org-github-issues.el
@@ -106,9 +106,10 @@
   "Return a list of gh-issues-issue objects from OWNER/REPO over CONNECTION."
   (let ((conn (or connection
                   (ogi--connect))))
-    (oref (gh-issues-issue-list conn
-                                owner
-                                repo)
+    (oref (ogi--issues-issue-list conn
+                                  owner
+                                  repo
+                                  (if (and org-github-issues-filter-by-assignee org-github-issues-assignee) org-github-issues-assignee nil))
           data)))
 
 (defun ogi--repo-header-exists-p (repository)
@@ -242,6 +243,19 @@
         (insert "\n")
         (insert body)
         (insert "\n")))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; rest methods
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod ogi--issues-issue-list ((api gh-issues-api) user repo &optional assignee)
+  (gh-api-authenticated-request
+   api (gh-object-list-reader (oref api issue-cls)) "GET"
+   (if assignee
+       (format "/repos/%s/%s/issues?assignee=%s" user repo assignee)
+     (format "/repos/%s/%s/issues" user repo))))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public functions


### PR DESCRIPTION
This pull request introduces the following:

- ability to define multiple custom regexp transformations when doing 'label to tag convertion'.
-  doc all options
- doc installation via straight.el and example usage
- perform filtering by assingee on api level to increase speed