### PR TITLE
feat: browse issue linked to the current org entry on github

### DIFF
--- a/org-github-issues.el
+++ b/org-github-issues.el
@@ -262,6 +262,17 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;###autoload
+(defun org-github-issues-browse-entry-at-point ()
+  "Browse the issue that corresponds to the org entry at point."
+  (interactive)
+  (let ((origin (current-buffer)))
+    (when (eq major-mode 'org-agenda-mode) (org-agenda-switch-to))
+    (let* ((p (point))
+           (url (string-trim (org-entry-get nil "GH_URL"))))
+      (when url (browse-url url))
+      (when (not (equal origin (current-buffer))) (switch-to-buffer origin)))))
+
+;;;###autoload
 (defun org-github-issues-sync-issues (repository)
   "Fetch and insert all open issues from github REPOSITORY.
 


### PR DESCRIPTION
This pull request adds a command that browsing the issue that corresponds to the current org entry on github.
It can be used with regular org buffers, or directly in the org-agenda.